### PR TITLE
Read program arguments if given

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::io;
 use std::io::Read;
 
@@ -17,24 +18,31 @@ fn parse_input_to_vector() -> Vec<String> {
             break;
         }
 
-        let input = input.replace("\n", &format!(" {} ", NEWLINE));
-        let input = input.split(" ");
+        lines.extend(input_to_center_aligned_vectors(&input));
+    }
+    lines
+}
 
-        let mut line = String::from("");
-        for word in input {
-            if word == NEWLINE {
-                lines.push(center_align(&line));
-                line = String::from("");
-            } else if word.len() + line.len() <= MAX_WIDTH {
-                line = line.to_owned() + " " + word;
-            } else {
-                lines.push(center_align(&line));
-                line = String::from(word);
-            }
-        }
-        if line.len() > 0 {
+fn input_to_center_aligned_vectors(input: &str) -> Vec<String> {
+    let mut lines: Vec<String> = vec![];
+ 
+    let input = input.replace("\n", &format!(" {} ", NEWLINE));
+    let input = input.split(" ");
+
+    let mut line = String::from("");
+    for word in input {
+        if word == NEWLINE {
             lines.push(center_align(&line));
+            line = String::from("");
+        } else if word.len() + line.len() <= MAX_WIDTH {
+            line = line.to_owned() + " " + word;
+        } else {
+            lines.push(center_align(&line));
+            line = String::from(word);
         }
+    }
+    if line.len() > 0 {
+        lines.push(center_align(&line));
     }
     lines
 }
@@ -53,9 +61,24 @@ fn center_align(line: &str) -> String {
     x
 }
 
+fn parse_arguments_to_vector() -> Vec<String> {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        return Vec::<String>::new();
+    } else {
+        return input_to_center_aligned_vectors(&args[1]);
+    }
+}
+
 fn main() {
     println!("{}", GARF_TOP);
-    let lines = parse_input_to_vector();
+
+    let mut lines = parse_arguments_to_vector();
+    if lines.len() == 0  {
+        lines = parse_input_to_vector();
+    }
+
     for line in &lines {
         println!("` m.. {} -m`", line);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,10 +64,11 @@ fn center_align(line: &str) -> String {
 fn parse_arguments_to_vector() -> Vec<String> {
     let args: Vec<String> = env::args().collect();
 
-    if args.len() != 2 {
+    if args.len() < 2 {
         return Vec::<String>::new();
     } else {
-        return input_to_center_aligned_strings(&args[1]);
+        let input = args[1..].join(" ");
+        return input_to_center_aligned_strings(&input);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,12 @@ fn parse_input_to_vector() -> Vec<String> {
             break;
         }
 
-        lines.extend(input_to_center_aligned_vectors(&input));
+        lines.extend(input_to_center_aligned_strings(&input));
     }
     lines
 }
 
-fn input_to_center_aligned_vectors(input: &str) -> Vec<String> {
+fn input_to_center_aligned_strings(input: &str) -> Vec<String> {
     let mut lines: Vec<String> = vec![];
  
     let input = input.replace("\n", &format!(" {} ", NEWLINE));
@@ -67,7 +67,7 @@ fn parse_arguments_to_vector() -> Vec<String> {
     if args.len() != 2 {
         return Vec::<String>::new();
     } else {
-        return input_to_center_aligned_vectors(&args[1]);
+        return input_to_center_aligned_strings(&args[1]);
     }
 }
 


### PR DESCRIPTION
Now also possible to

```
$ garfsay "Hello world"
```

in addition to

```
$ echo "Hello world" | garfsay
```

If program arguments are given, then `stdin` will not be read.

In this same PR move input centering to its own function as argument parsing also uses that functionality.